### PR TITLE
Change minimum requirement version to OMNeT++ 4.6

### DIFF
--- a/.project
+++ b/.project
@@ -3,7 +3,7 @@
 	<name>IEEE802154INET-Standalone</name>
 	<comment></comment>
 	<projects>
-		<project>inet-2.6</project>
+		<project>inet</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A new IEEE 802.15.4-2006 Simulation Model for OMNeT++ / INET
 
 Minimum requirements are:
 
-- OMNeT++ 4.3 version (tested up to 5.0-Beta1)
-- INET 2.x (!) version (tested with 2.2 to 2.6)
+- OMNeT++ 4.6 version
+- INET 2.x (!) version (tested with 2.4 to 2.6)
   - Minimal set of enabled project features: IPv4, IPv6, Mobility, Radio
 - Windows or Linux operating system
 


### PR DESCRIPTION
I think it is best to change minimum requirement to OMNeT++ 4.6 because the old version 4.3 didn't work. Just suggestion if you like it.